### PR TITLE
Sbus for receiver

### DIFF
--- a/Generic.ino
+++ b/Generic.ino
@@ -37,9 +37,9 @@ void manage_servos() {
       for (uint8_t i = 0; i < SERVO_CHANNELS; i++)
         Servos[i] = Servo_Buffer[i];
   #ifdef INJECT_RSSI_IN_CH
-    Servos[INJECT_RSSI_IN_CH] = map(calculated_rssi, 0, 100, 1000, 2000);
-    //Servos[INJECT_RSSI_IN_CH+1] = map(calculated_lost_frames_rssi, 0, 100, 1000, 2000);
-    //Servos[INJECT_RSSI_IN_CH+2] = map(current_power, tx_power_low, tx_power_high, 1000, 2000);
+    Servos[INJECT_RSSI_IN_CH] = map(calculated_rssi, 0, 100, 1000, 2000);   // inject calculated RSSI to %
+    //Servos[INJECT_RSSI_IN_CH-1] = map(calculated_lost_frames_rssi, 0, 100, 1000, 2000);   // inject RSSI based on lost frames
+    //Servos[INJECT_RSSI_IN_CH+2] = map(current_power, tx_power_low, tx_power_high, 1000, 2000);  // inject current power level
   #endif
 }
 

--- a/LoRaRC.ino
+++ b/LoRaRC.ino
@@ -21,6 +21,7 @@
   #endif
   static unsigned long TX_period = F_rate_low;  // 7700 / 20000 / 40000  us
   static unsigned long ibus_frame_period = 7500; //us (so far the smallest delays with 7,5ms, measured frame rate 7,7 to 8,5ms
+  static unsigned long sbus_frame_period = 15000;
   static unsigned long RX_last_frame_received, RX_hopping_time;
   static unsigned long RX_frame_time;
   static unsigned long timer_start, timer_stop;
@@ -42,7 +43,12 @@
   static bool failsafe_state = true;    // sending Failsafe values by default
   
 void setup() {
-  Serial.begin(115200);
+  #ifdef SBUS_module
+    Serial.begin(100000, SERIAL_8E2);
+  #else
+    Serial.begin(115200);
+  #endif
+  
   // while (!Serial);
   wdt_enable(WDTO_250MS);
   
@@ -256,6 +262,12 @@ void loop() {
     #endif
   }
   if (micros() > RX_frame_time) {
+    // SBUS
+    #ifdef SBUS_module
+    send_servo_frame();   // fail safe is inside
+    RX_frame_time = micros() + sbus_frame_period;
+    #endif // SBUS_module
+    
     // IBUS
     #ifdef IBUS_module
       #ifdef DEBUG_RX_OUTPUT

--- a/Servos.ino
+++ b/Servos.ino
@@ -48,4 +48,3 @@ void servoTester() {
   for (char i=0; i<8; i++)
     Servos[i] = (i != 2 ? swipeval : Servos[i]);
 }
-

--- a/config.h
+++ b/config.h
@@ -48,7 +48,7 @@ const uint8_t hop_list[] = {5,7,12};
 volatile unsigned int Servo_Buffer[SERVO_CHANNELS] = {1500, 1500, 1000, 1500, 1500, 1500, 1500, 1500};
 unsigned int Servos[SERVO_CHANNELS] = {1500, 1500, 1000, 1500, 1500, 1500, 1500, 1500};  
 unsigned int Servo_Failsafe[SERVO_CHANNELS] = {1500, 1500, 900, 1500, 1500, 1500, 1500, 150};
-#define FAILSAFE_DELAY_MS 200
+#define FAILSAFE_DELAY_MS 800
 
 #define SERVO_SHIFT 0   //(-16)   // PPM = -16  |  others = 0
 

--- a/config.h
+++ b/config.h
@@ -4,19 +4,19 @@ enum stateMachineDef {SETUP = 0, TRANSMIT = 1, RECEIVE = 2, BIND = 3 };
 // Dubugging - select any
 //#define DEBUG_CH_FREQ
 //#define DEBUG_RADIO_EXCH
-#define DEBUG_ANALYZER
+//#define DEBUG_ANALYZER
 //#define TX_SERVO_TESTER
 //#define DEBUG_RX_OUTPUT
 
 // Transmitter or Receiver - select one
-#define TX_module
-//#define RX_module
+//#define TX_module
+#define RX_module
 
 // Communication type - select one
-#define PPM_module  // using ICP for TX or declared for TX
+//#define PPM_module  // using ICP for TX or declared for TX
 //#define IBUS_module   // using UART
+#define SBUS_module   // using UART at 100000N2
 //#define MSP_module   // using UART
-//#define FRSKY_module
 
 // Transmitting power in dBm: 2 to 20, default 17
 byte tx_power_low = 4;    //  4=>2.5mW; 6=>5mW; 10=>10mW
@@ -47,7 +47,7 @@ const uint8_t hop_list[] = {5,7,12};
 #define SERVO_CHANNELS 8
 volatile unsigned int Servo_Buffer[SERVO_CHANNELS] = {1500, 1500, 1000, 1500, 1500, 1500, 1500, 1500};
 unsigned int Servos[SERVO_CHANNELS] = {1500, 1500, 1000, 1500, 1500, 1500, 1500, 1500};  
-unsigned int Servo_Failsafe[SERVO_CHANNELS] = {1500, 1500, 900, 1500, 1500, 1500, 1500, 1500};
+unsigned int Servo_Failsafe[SERVO_CHANNELS] = {1500, 1500, 900, 1500, 1500, 1500, 1500, 150};
 #define FAILSAFE_DELAY_MS 200
 
 #define SERVO_SHIFT 0   //(-16)   // PPM = -16  |  others = 0

--- a/ibus.ino
+++ b/ibus.ino
@@ -2,8 +2,8 @@
 
 /**
  * iBus protocol generator by Konrad Winiarski
- * - why iBus? Latency! Frame sent to FC every 7ms!
- * - 14 channels by default !!
+ * - why iBus? Latency! Frame sent to FC every 7ms! (can vary in wide range without impact on link quality)
+ * - 14 channels by default !! in 32 bytes
  * - support bi-directional communication (just in case)
  * - consumes UART, SoftSerial does not work at 115200 :(
  * 

--- a/sbus.ino
+++ b/sbus.ino
@@ -50,7 +50,7 @@ void send_servo_frame(){
 
     uint8_t stateByte = 0x00;
     
-    if (lost_frames > 6) {
+    if (lost_frames > 12) {
         stateByte |= SBUS_STATE_SIGNALLOSS;
     }
     if (failsafe_state) {

--- a/sbus.ino
+++ b/sbus.ino
@@ -1,0 +1,119 @@
+#ifdef SBUS_module
+/**
+ * Tested with SP Racing f3 flight controller and iNav.
+ * Still Beta, not tested in flight yet.
+ * With this communication type, UART is set to 100000 8E2. Standard Arduino monitor is not supporting this speed, so don't bother. Use Putty.
+ * 
+ * Based on code of Pawel Spychalski:
+ * https://quadmeup.com/generate-s-bus-with-arduino-in-a-simple-way/
+ * 
+ * For some reason, there is an error when trying to create pocket first, then send it by Serial.write(pocket);
+ * If there is "\0" Serial function deos not send it. When trying to change data type or setting fixed buffer length, there is an error during compilation.
+ * Maybe someone will find and fix the proble someday. For now, there are plenty of Serial.write() calls.
+ */
+#ifdef RX_module
+
+#define RC_CHANNEL_MIN 990
+#define RC_CHANNEL_MAX 2010
+
+#define SBUS_MIN_OFFSET 173
+#define SBUS_MID_OFFSET 992
+#define SBUS_MAX_OFFSET 1811
+#define SBUS_CHANNEL_NUMBER 16
+#define SBUS_PACKET_LENGTH 25
+#define SBUS_FRAME_HEADER 0x0f
+#define SBUS_FRAME_FOOTER 0x00
+#define SBUS_FRAME_FOOTER_V2 0x04
+#define SBUS_STATE_FAILSAFE 0x08
+#define SBUS_STATE_SIGNALLOSS 0x04
+#define SBUS_UPDATE_RATE 15 //ms
+
+void setup_module() {
+    // module works on hardware serial - must be 100000/8E2
+    //Serial.end();
+    //Serial.begin(100000, SERIAL_8E2);
+}
+
+
+void send_servo_frame(){
+
+    unsigned char packet[25];
+    static int output[SBUS_CHANNEL_NUMBER] = {0};
+
+    /*
+     * Map 1000-2000 with middle at 1500 chanel values to
+     * 173-1811 with middle at 992 S.BUS protocol requires
+     */
+    for (uint8_t i = 0; i < SBUS_CHANNEL_NUMBER; i++) {
+        output[i] = map( (i < SERVO_CHANNELS ? (Servos[i] + SERVO_SHIFT) : 1500), RC_CHANNEL_MIN, RC_CHANNEL_MAX, SBUS_MIN_OFFSET, SBUS_MAX_OFFSET);
+    }
+
+    uint8_t stateByte = 0x00;
+    
+    if (lost_frames > 6) {
+        stateByte |= SBUS_STATE_SIGNALLOSS;
+    }
+    if (failsafe_state) {
+        stateByte |= SBUS_STATE_FAILSAFE;
+    }
+    /*
+    packet[0] = SBUS_FRAME_HEADER; //Header
+    packet[1] = (uint8_t) (output[0] & 0x07FF);
+    packet[2] = (uint8_t) ((output[0] & 0x07FF)>>8 | (output[1] & 0x07FF)<<3);
+    packet[3] = (uint8_t) ((output[1] & 0x07FF)>>5 | (output[2] & 0x07FF)<<6);
+    packet[4] = (uint8_t) ((output[2] & 0x07FF)>>2);
+    packet[5] = (uint8_t) ((output[2] & 0x07FF)>>10 | (output[3] & 0x07FF)<<1);
+    packet[6] = (uint8_t) ((output[3] & 0x07FF)>>7 | (output[4] & 0x07FF)<<4);
+    packet[7] = (uint8_t) ((output[4] & 0x07FF)>>4 | (output[5] & 0x07FF)<<7);
+    packet[8] = (uint8_t) ((output[5] & 0x07FF)>>1);
+    packet[9] = (uint8_t) ((output[5] & 0x07FF)>>9 | (output[6] & 0x07FF)<<2);
+    packet[10] = (uint8_t) ((output[6] & 0x07FF)>>6 | (output[7] & 0x07FF)<<5);
+    packet[11] = (uint8_t) ((output[7] & 0x07FF)>>3);
+    packet[12] = (uint8_t) ((output[8] & 0x07FF));
+    packet[13] = (uint8_t) ((output[8] & 0x07FF)>>8 | (output[9] & 0x07FF)<<3);
+    packet[14] = (uint8_t) ((output[9] & 0x07FF)>>5 | (output[10] & 0x07FF)<<6);  
+    packet[15] = (uint8_t) ((output[10] & 0x07FF)>>2);
+    packet[16] = (uint8_t) ((output[10] & 0x07FF)>>10 | (output[11] & 0x07FF)<<1);
+    packet[17] = (uint8_t) ((output[11] & 0x07FF)>>7 | (output[12] & 0x07FF)<<4);
+    packet[18] = (uint8_t) ((output[12] & 0x07FF)>>4 | (output[13] & 0x07FF)<<7);
+    packet[19] = (uint8_t) ((output[13] & 0x07FF)>>1);
+    packet[20] = (uint8_t) ((output[13] & 0x07FF)>>9 | (output[14] & 0x07FF)<<2);
+    packet[21] = (uint8_t) ((output[14] & 0x07FF)>>6 | (output[15] & 0x07FF)<<5);
+    packet[22] = (uint8_t) ((output[15] & 0x07FF)>>3);
+    packet[23] = (uint8_t) stateByte; //Flags byte
+    packet[24] = (uint8_t) SBUS_FRAME_FOOTER; //Footer
+*/
+
+    Serial.write(SBUS_FRAME_HEADER);
+    Serial.write(output[0] & 0x07FF);
+    Serial.write((output[0] & 0x07FF)>>8 | (output[1] & 0x07FF)<<3);
+
+    Serial.write((output[1] & 0x07FF)>>5 | (output[2] & 0x07FF)<<6);
+    Serial.write((output[2] & 0x07FF)>>2);
+    Serial.write((output[2] & 0x07FF)>>10 | (output[3] & 0x07FF)<<1);
+    Serial.write((output[3] & 0x07FF)>>7 | (output[4] & 0x07FF)<<4);
+    Serial.write((output[4] & 0x07FF)>>4 | (output[5] & 0x07FF)<<7);
+    Serial.write((output[5] & 0x07FF)>>1);
+    Serial.write((output[5] & 0x07FF)>>9 | (output[6] & 0x07FF)<<2);
+    Serial.write((output[6] & 0x07FF)>>6 | (output[7] & 0x07FF)<<5);
+    Serial.write((output[7] & 0x07FF)>>3);
+    Serial.write((output[8] & 0x07FF));
+    Serial.write((output[8] & 0x07FF)>>8 | (output[9] & 0x07FF)<<3);
+    Serial.write((output[9] & 0x07FF)>>5 | (output[10] & 0x07FF)<<6);  
+    Serial.write((output[10] & 0x07FF)>>2);
+    Serial.write((output[10] & 0x07FF)>>10 | (output[11] & 0x07FF)<<1);
+    Serial.write((output[11] & 0x07FF)>>7 | (output[12] & 0x07FF)<<4);
+    Serial.write((output[12] & 0x07FF)>>4 | (output[13] & 0x07FF)<<7);
+    Serial.write((output[13] & 0x07FF)>>1);
+    Serial.write((output[13] & 0x07FF)>>9 | (output[14] & 0x07FF)<<2);
+    Serial.write((output[14] & 0x07FF)>>6 | (output[15] & 0x07FF)<<5);
+    Serial.write((output[15] & 0x07FF)>>3);
+    Serial.write (stateByte); //Flags byte
+    Serial.write(SBUS_FRAME_FOOTER); //Footer
+}
+
+
+
+#endif // RX module
+
+#endif // IBUS_module


### PR DESCRIPTION
Implemented sbus protocol generation on hardware UART of receiver module.
UART port configured to: 100000 bps 8E2.  It is not inverted signal - make sure it is configured proporly in FC.
At this point UART is useless for other features, like debugging. Maybe for telemetry (S.PORT) in the future, once it uses same transmission parameters.
Feature tested with "servo tester" function in TX module (swipe continuously RC data). Changing status byte to Failsafe (once connection is lost) also works as intendent. 
There is also intermediate step when signal loss occurs - also status byte is set.